### PR TITLE
Fix sepolicy for kernel < 5.10 that doesn't support bpf file context

### DIFF
--- a/private/network_stack.te
+++ b/private/network_stack.te
@@ -61,8 +61,8 @@ hal_client_domain(network_stack, hal_tetheroffload)
 allow network_stack self:netlink_netfilter_socket create_socket_perms_no_ioctl;
 allow network_stack network_stack_service:service_manager find;
 # allow Tethering(network_stack process) to run/update/read the eBPF maps to offload tethering traffic by eBPF.
-allow network_stack { fs_bpf_net_private fs_bpf_net_shared fs_bpf_netd_readonly fs_bpf_netd_shared fs_bpf_tethering }:dir search;
-allow network_stack { fs_bpf_net_private fs_bpf_net_shared fs_bpf_netd_readonly fs_bpf_netd_shared fs_bpf_tethering }:file { getattr read write };
+allow network_stack { fs_bpf fs_bpf_net_private fs_bpf_net_shared fs_bpf_netd_readonly fs_bpf_netd_shared fs_bpf_tethering }:dir search;
+allow network_stack { fs_bpf fs_bpf_net_private fs_bpf_net_shared fs_bpf_netd_readonly fs_bpf_netd_shared fs_bpf_tethering }:file { getattr read write };
 allow network_stack bpfloader:bpf { map_read map_write prog_run };
 # allow Tethering(network_stack process) to read flag value in tethering_u_or_later_native namespace
 get_prop(network_stack, device_config_tethering_u_or_later_native_prop)


### PR DESCRIPTION
Same problem as in p/m/Connectivity 110d777311b9851a8e007860d15c0dc714c3d82d

Error message:

```
E BpfCoordinator: Cannot create downstream6 map: android.system.ErrnoException: nativeBpfFdGet failed: EACCES (Permission denied)
E BpfCoordinator: Cannot create upstream6 map: android.system.ErrnoException: nativeBpfFdGet failed: EACCES (Permission denied)
E BpfCoordinator: Cannot create stats map: android.system.ErrnoException: nativeBpfFdGet failed: EACCES (Permission denied)
E BpfCoordinator: Cannot create limit map: android.system.ErrnoException: nativeBpfFdGet failed: EACCES (Permission denied)
E BpfCoordinator: Cannot create dev map: android.system.ErrnoException: nativeBpfFdGet failed: EACCES (Permission denied)
W rkstack.process: type=1400 audit(0.0:125): avc:  denied  { read write } for  name="map_offload_tether_downstream6_map" dev="bpf" ino=33961 scontext=u:r:network_stack:s0 tcontext=u:object_r:fs_bpf:s0 tclass=file permissive=0
W rkstack.process: type=1400 audit(0.0:126): avc:  denied  { read write } for  name="map_offload_tether_upstream6_map" dev="bpf" ino=33963 scontext=u:r:network_stack:s0 tcontext=u:object_r:fs_bpf:s0 tclass=file permissive=0
```